### PR TITLE
Added Fast_Modulo_Expoenent solution

### DIFF
--- a/src/05_Fast_Modulo_Exponent/solution.cpp
+++ b/src/05_Fast_Modulo_Exponent/solution.cpp
@@ -1,0 +1,24 @@
+#include <bits/stdc++.h>
+using namespace std;
+
+// Fast modular exponentiation: computes (base^exp) % mod
+long long solution(long long base, long long exp, long long mod) {
+    long long res = 1 % mod;  // in case mod = 1
+    base %= mod;
+    while (exp > 0) {
+        if (exp & 1) res = (res * base) % mod;
+        base = (base * base) % mod;
+        exp >>= 1;
+    }
+    return res;
+}
+
+int main() {
+
+    long long base, exp, mod;
+    cout << "Enter base, exponent, modulus: ";
+    cin >> base >> exp >> mod;
+
+    cout << "Answer: " << solution(base, exp, mod) << "\n";
+    return 0;
+}


### PR DESCRIPTION
## Description

# Problem
We need to compute: (base^exponent) mod modulus efficiently, without directly calculating base^exponent (which can be extremely large).

⚡ Approach: Fast Modular Exponentiation (Binary Exponentiation)

The naive method of multiplying base repeatedly exp times is O(exp), which is too slow for large exponents.  
Instead, we use binary exponentiation, which reduces the time complexity to O(log exp).

## Key Idea:

- Write the exponent in binary.
- For each bit:
  - If the bit is 1, multiply the result with the current base.
  - Square the base for the next bit.
  - Move to the next bit by right-shifting the exponent.

This ensures at most log2(exp) multiplications.

Fixes #(6)

