### PR TITLE
feat(01_dearrangements/c): add C implementation of derangements with modulo support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@
 *.exe
 *.out
 *.appsrc/03_Josephers/c/josephus
+src/01_dearrangements/c/derangements

--- a/.gitignore
+++ b/.gitignore
@@ -29,4 +29,4 @@
 # Executables
 *.exe
 *.out
-*.app
+*.appsrc/03_Josephers/c/josephus

--- a/src/01_dearrangements/c/derangements.c
+++ b/src/01_dearrangements/c/derangements.c
@@ -1,0 +1,62 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <limits.h>
+
+static unsigned long long derange_exact(unsigned n) {
+    if (n == 0) return 1ULL;
+    if (n == 1) return 0ULL;
+    unsigned long long d0 = 1ULL;
+    unsigned long long d1 = 0ULL;
+    for (unsigned i = 2; i <= n; ++i) {
+        unsigned long long next = (unsigned long long)(i - 1) * (d0 + d1);
+        d0 = d1;
+        d1 = next;
+    }
+    return d1;
+}
+
+static unsigned long long derange_mod(unsigned n, unsigned long long m) {
+    if (m == 0ULL) return 0ULL;
+    if (n == 0) return 1ULL % m;
+    if (n == 1) return 0ULL;
+    unsigned long long d0 = 1ULL % m;
+    unsigned long long d1 = 0ULL;
+    for (unsigned i = 2; i <= n; ++i) {
+        unsigned long long next = ((i - 1) % m) * ((d0 + d1) % m) % m;
+        d0 = d1 % m;
+        d1 = next;
+    }
+    return d1 % m;
+}
+
+static int usage(const char *prog) {
+    fprintf(stderr, "Usage: %s <n>=0 [mod>0]\n", prog);
+    fprintf(stderr, "  (Exact for n<=20 without mod; use [mod] for large n.)\n");
+    return 1;
+}
+
+int main(int argc, char *argv[]) {
+    if (argc != 2 && argc != 3) return usage(argv[0]);
+
+    char *end = NULL;
+    errno = 0;
+    long long nll = strtoll(argv[1], &end, 10);
+    if (errno || *end != '\0' || nll < 0) return usage(argv[0]);
+    unsigned n = (unsigned)nll;
+
+    if (argc == 3) {
+        errno = 0;
+        unsigned long long mod = strtoull(argv[2], &end, 10);
+        if (errno || *end != '\0' || mod == 0ULL) return usage(argv[0]);
+        printf("%llu\n", derange_mod(n, mod));
+        return 0;
+    }
+
+    if (n > 20) {
+        fprintf(stderr, "n too large for exact 64-bit result (max 20). Use the 'mod' form.\n");
+        return 1;
+    }
+    printf("%llu\n", derange_exact(n));
+    return 0;
+}

--- a/src/03_Josephers/c/josephus.c
+++ b/src/03_Josephers/c/josephus.c
@@ -1,0 +1,23 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+static long long josephus(long long n, long long k) {
+    long long res = 0;
+    for (long long i = 1; i <= n; ++i) res = (res + k) % i;
+    return res + 1; /* 1-based position */
+}
+
+int main(int argc, char **argv) {
+    if (argc != 3) {
+        fprintf(stderr, "Usage: %s <n> >0 <k> >0\n", argv[0]);
+        return 1;
+    }
+    long long n = atoll(argv[1]);
+    long long k = atoll(argv[2]);
+    if (n <= 0 || k <= 0) {
+        fprintf(stderr, "n and k must be positive\n");
+        return 1;
+    }
+    printf("%lld\n", josephus(n, k));
+    return 0;
+}


### PR DESCRIPTION
This PR adds a C solution for 01_dearrangements.

What’s included

src/01_dearrangements/c/derangements.c

Iterative recurrence:
D(0)=1, D(1)=0, D(n)=(n−1)·(D(n−1)+D(n−2))

Two modes:

Exact result (no modulo) for n ≤ 20 (fits in 64-bit).

Modulo result for any n with user-supplied mod > 0.

Input validation & helpful usage messages.

.gitignore entry to ignore the compiled binary.